### PR TITLE
Fix conflicting ObjectGraph providers

### DIFF
--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ActivityModule.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ActivityModule.java
@@ -27,6 +27,7 @@ public class ActivityModule {
 
 	@Provides
 	@Singleton
+	@ForActivity
 	ObjectGraph provideActivityGraph() {
 		DaggerContext context = (DaggerContext) mActivity;
 		return context.getObjectGraph();

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/AndroidModule.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/AndroidModule.java
@@ -51,6 +51,7 @@ public class AndroidModule {
 
 	@Provides
 	@Singleton
+	@ForApplication
 	ObjectGraph provideApplicationGraph() {
 		return ((DaggerContext) mApplication).getObjectGraph();
 	}

--- a/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ServiceModule.java
+++ b/DaggerAndroidHelperLibrary/src/main/java/com/anprosit/android/dagger/ServiceModule.java
@@ -4,7 +4,6 @@ import android.app.Service;
 import android.content.Context;
 
 import com.anprosit.android.dagger.annotation.ForService;
-import com.anprosit.android.dagger.service.DaggerService;
 
 import javax.inject.Singleton;
 
@@ -28,6 +27,7 @@ public class ServiceModule {
 
 	@Provides
 	@Singleton
+	@ForService
 	ObjectGraph provideServiceGraph() {
 		return ((DaggerContext) mService).getObjectGraph();
 	}


### PR DESCRIPTION
``` java
@Module(
        addsTo = MiteneApplicationModule.class,
        includes = ActivityModule.class,
        injects = {
          ...
```

Above example will cause below exception.

```
Unknown error java.lang.IllegalArgumentException thrown by javac in graph validation: Duplicate:
ProvidesBinding[key=dagger.ObjectGraph method=com.anprosit.android.dagger.ActivityModule.provideActivityGraph()
ProvidesBinding[key=dagger.ObjectGraph method=com.anprosit.android.dagger.AndroidModule.provideApplicationGraph()
```

This PR fixes it by adding `@ForActivity`, `@ForService` and `@ForApplciation` qualifier annotations.

Thanks!
